### PR TITLE
Fix command examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ $LOOM_EXE init
 
 ## Creating an account and running transactions
 ```
+export ETHERBOY_CLI="/path/to/etherboycli"
+
 # create a key pair
-LOOM_CMDPLUGINDIR=cmds/ $LOOM_ADM genkey -a address.pub -k priv
+LOOM_CMDPLUGINDIR=cmds/ $ETHERBOY_CLI genkey -k priv
 
 # send a create account tx
-LOOM_CMDPLUGINDIR=cmds/ $LOOM_ADM create-acct -a address.pub -k priv 
+LOOM_CMDPLUGINDIR=cmds/ $ETHERBOY_CLI create-acct -k priv -u loom 
 
 # send a set stage tx
-LOOM_CMDPLUGINDIR=cmds/ $LOOM_ADM set -v 1010 -a address.pub -k priv
+LOOM_CMDPLUGINDIR=cmds/ $ETHERBOY_CLI set -v 1010 -k priv -u loom
 ```
 
 ## Regenerating Protobufs


### PR DESCRIPTION
etherboycli does not support command flag `a`. This commit updates the document to reflect that.
It also adds some cosmetic changes.